### PR TITLE
some improvements trying to normalize paths for Windows or UNIX-like (still not working)

### DIFF
--- a/R/Launch.R
+++ b/R/Launch.R
@@ -43,7 +43,7 @@ Launch <- function(inputDir= NULL,
     # server <- getServer(exampleDir, inputDir)
     # shinyApp(ui, server, options = list(launch.browser = TRUE))
     appDir <- system.file('app', package = "xROI")
-    writeLines(c(exampleDir, inputDir), file.path(normalizePath(tempdir(), winslash = "/"), 'ex_in_dir.tmp', fsep= "/"), sep = "/")
+    writeLines(c(exampleDir, inputDir), file.path(normalizePath(tempdir(), winslash = "/"), 'ex_in_dir.tmp', fsep= "/")) #, sep = "/"
     shinyAppDir(appDir = appDir, options = list(launch.browser = TRUE))
   }else{
     print('This function requires an interactive R session!')

--- a/R/Launch.R
+++ b/R/Launch.R
@@ -36,14 +36,14 @@ Launch <- function(inputDir= NULL,
   #exampleFiles <- "D:/Projects/xROI/inst/example"
   tmpdir <- normalizePath(tempdir(), winslash = "/")
   file.copy(exampleFiles, tmpdir, recursive = T)
-  exampleDir <- normalizePath(file.path(tmpdir, 'example'))
+  exampleDir <- normalizePath(file.path(tmpdir, 'example'), winslash = "/")
   ## Only run examples in interactive R sessions
   if (interactive()|Interactive) {
     # ui <- getUI()
     # server <- getServer(exampleDir, inputDir)
     # shinyApp(ui, server, options = list(launch.browser = TRUE))
     appDir <- system.file('app', package = "xROI")
-    writeLines(c(exampleDir, inputDir), file.path(tempdir(), 'ex_in_dir.tmp'))
+    writeLines(c(exampleDir, inputDir), file.path(normalizePath(tempdir(), winslash = "/"), 'ex_in_dir.tmp', fsep= "/"), sep = "/")
     shinyAppDir(appDir = appDir, options = list(launch.browser = TRUE))
   }else{
     print('This function requires an interactive R session!')

--- a/R/Launch.R
+++ b/R/Launch.R
@@ -33,7 +33,8 @@
 Launch <- function(inputDir= NULL,
                    Interactive = FALSE){
   exampleFiles <- system.file('example', package = "xROI")
-  tmpdir <- tempdir()
+  #exampleFiles <- "D:/Projects/xROI/inst/example"
+  tmpdir <- normalizePath(tempdir(), winslash = "/")
   file.copy(exampleFiles, tmpdir, recursive = T)
   exampleDir <- normalizePath(file.path(tmpdir, 'example'))
   ## Only run examples in interactive R sessions
@@ -42,7 +43,7 @@ Launch <- function(inputDir= NULL,
     # server <- getServer(exampleDir, inputDir)
     # shinyApp(ui, server, options = list(launch.browser = TRUE))
     appDir <- system.file('app', package = "xROI")
-    writeLines(c(exampleDir, inputDir), paste0(tempdir(), '/ex_in_dir.tmp'))
+    writeLines(c(exampleDir, inputDir), file.path(tempdir(), 'ex_in_dir.tmp'))
     shinyAppDir(appDir = appDir, options = list(launch.browser = TRUE))
   }else{
     print('This function requires an interactive R session!')

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -61,7 +61,8 @@ server <-
       keep <- !tolower(volumes) %in% c("name", "")
       volumes <- volumes[keep]
       names(volumes) <- volumes
-      roots <- c('Example'= exampleDir, Home=path.expand('~/../'), volumes)
+      #roots <- c('Example'= exampleDir, Home = path.expand('~/../'), volumes)
+      roots <- c('Example'= exampleDir, Home = path.expand('~'), volumes)
     }
 
     observe({

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -1,6 +1,8 @@
 library(xROI)
 
-ex_in_dir <- readLines(paste0(tempdir(), '/ex_in_dir.tmp'))
+#ex_in_dir <- readLines(paste0(tempdir(), '/ex_in_dir.tmp')) #this is not working in Windows
+
+ex_in_dir <- readLines(file.path(normalizePath(tempdir(), winslash = "/"), 'ex_in_dir.tmp'))
 
 exampleDir <- ex_in_dir[1]
 inputDir <- ex_in_dir[2]

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -52,10 +52,10 @@ server <-
                          cliclickID = NULL)
 
 
-    roots = list(root='/', Home=path.expand('~'),'Example' = exampleDir)
+    roots = list(root='/', Home = path.expand('~'),'Example' = exampleDir)
     if(Sys.info()['sysname']=='Windows'){
       volumes <- system("wmic logicaldisk get name", intern = T)
-      volumes <- sub(" *\\r$", "", volumes)
+      volumes <- sub(" *\r$", "", volumes)
       keep <- !tolower(volumes) %in% c("name", "")
       volumes <- volumes[keep]
       names(volumes) <- volumes


### PR DESCRIPTION
I have done these improvements so far, but the package is still not working. I have tried to replace all the possible paths in which Windows could put double slash as a separator, and tried to force them to be single slash. However, I might have missed some. I guess it is better to review the changes before accepting the pull request, but I wanted to share this with you in any case. Thank you so much for the help!